### PR TITLE
Fix `ownershipscheme` ABNF grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ The use case of "pairing" two DIDs by delegating all current and future resource
 The format for this scheme is as follows:
 
 ``` abnf
-ownershipscheme = "my:" kind ["@" did]
+ownershipscheme = "my:" kind
 kind = "*" / <scheme> 
 ```
 
@@ -400,7 +400,7 @@ kind = "*" / <scheme>
 
 ### 4.2.2 Action
 
-The action for `my:*` or `as:*` MUST be the [superuser action `*`](#41-superuser). Another ability would not be possible, since any other ability cannot be guaranteed to work across all resource types (e.g. it's not possible to `crud/UPDATE` an email address). Recall that the superuser action is special in that it selects the maximum possible action for any resource.
+The action for `my:*` or `as:<did>:*` MUST be the [superuser action `*`](#41-superuser). Another ability would not be possible, since any other ability cannot be guaranteed to work across all resource types (e.g. it's not possible to `crud/UPDATE` an email address). Recall that the superuser action is special in that it selects the maximum possible action for any resource.
 
 ``` json
 {"with": "my:*", "can": "*"}


### PR DESCRIPTION
According to @expede:

> Yeah it’s a relic from an old ABNF

Where "it" refers to tagging the DID in the `my:*` scheme.