### PR TITLE
0.9: Namespace all UCAN-spec required resources (e.g. my and as)

### DIFF
--- a/.custom-words.txt
+++ b/.custom-words.txt
@@ -99,6 +99,7 @@ subdelegate
 tradeoffs
 trustless
 trustlessly
+ucan
 un
 unary
 unresolvable

--- a/README.md
+++ b/README.md
@@ -344,8 +344,8 @@ The same resource MAY be addressed with several URI formats. For instance, a dat
 | URI                                            | Meaning                                                         |
 | ---------------------------------------------- | --------------------------------------------------------------- |
 | `{"with": "mailto:username@example.com", ...}` | A single email address                                          |
-| `{"with": "my:*", ...}`                        | All resources that the iss has access to, including future ones |
-| `{"with": "my:dnslink", ...}`                  | All DNSLinks that the iss has access to, including future ones  |
+| `{"with": "ucan:my:*", ...}`                   | All resources that the iss has access to, including future ones |
+| `{"with": "ucan:my:dnslink", ...}`             | All DNSLinks that the iss has access to, including future ones  |
 | `{"with": "dnslink://myapp.example.com", ...}` | A mutable pointer to some data                                  |
 
 #### 3.2.5.2 Ability
@@ -455,7 +455,7 @@ The use case of "pairing" two DIDs by delegating all current and future resource
 The format for this scheme is as follows:
 
 ``` abnf
-ownershipscheme = "my:" target
+ownershipscheme = "ucan:my:" target
 target = "*" / <scheme> / <uri>
 ```
 
@@ -470,7 +470,7 @@ Without this prefix, the ambiguity in provenance can be exploited by a malicious
 ```js
 // By parenthood
 {
-  "with": "my:email:alice@example.com",
+  "with": "ucan:my:email:alice@example.com",
   "can": "msg/send"
 }
 
@@ -481,69 +481,69 @@ Without this prefix, the ambiguity in provenance can be exploited by a malicious
 }
 ```
 
-### 4.2.2 `my` Wildcard
+### 4.2.2 `ucan:my` Wildcard
 
-The wildcard `my:*` resource MUST be taken to mean "everything" (all resources of all types) that are owned by the current DID.
+The wildcard `ucan:my:*` resource MUST be taken to mean "everything" (all resources of all types) that are owned by the current DID.
 
 ### 4.2.3 Subschemes
 
 A "sub-scheme" MAY be used to delegate some of that scheme controlled by parenthood. For example, `my:dns` delegates access to all DNS records. `my:mailto` selects all owned email addresses controlled by this user.
 
-### 4.2.4 `as:` Redelegation
+### 4.2.4 `ucan:as:` Redelegation
 
-Redelegating these to further DIDs in a chain MUST use the `as` URI and address the specific parent DID that owns that resource, followed by the resource kind selector. For instance: `as:did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp:*` selects all resources originating from the specified DID, and `as:did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp:mailto` selects email addresses from the DID. 
+Redelegating these to further DIDs in a chain MUST use the `as` URI and address the specific parent DID that owns that resource, followed by the resource kind selector. For instance: `ucan:as:did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp:*` selects all resources originating from the specified DID, and `as:did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp:mailto` selects email addresses from the DID. 
 
 ``` abnf
-delegatescheme = "as:" did ":" kind
+delegatescheme = "ucan:as:" did ":" kind
 kind = "*" / <scheme>
 ```
 
 ### 4.2.5 Ability
 
-The ability for `my:*` or `as:<did>:*` MUST be the [superuser ability `*`](#41-superuser). Another ability would not be possible since any other ability cannot be guaranteed to work across all resource types (e.g. it's not possible to `crud/UPDATE` an email address). Recall that the superuser ability is special in that it selects the maximum possible ability for any resource.
+The ability for `ucan:my:*` or `ucan:as:<did>:*` MUST be the [superuser ability `*`](#41-superuser). Another ability would not be possible since any other ability cannot be guaranteed to work across all resource types (e.g. it's not possible to `crud/UPDATE` an email address). Recall that the superuser ability is special in that it selects the maximum possible ability for any resource.
 
 ``` json
-{"with": "my:*", "can": "*"}
-{"with": "as:did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp:*", "can": "*"}
+{"with": "ucan:my:*", "can": "*"}
+{"with": "ucan:as:did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp:*", "can": "*"}
 
-{"with": "my:mailto", "can": "msg/SEND"}
-{"with": "as:did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp:mailto", "can": "msg/SEND"}
+{"with": "ucan:my:mailto", "can": "msg/SEND"}
+{"with": "ucan:as:did:key:z6MkiTBz1ymuepAQ4HEHYSF1H8quG5GLVVQR3djdX3mDooWp:mailto", "can": "msg/SEND"}
 ```
 
-For `my` and `as` capabilities limited to some scheme, the ability MUST be one normally associated with that resource. As it belongs to every ability hierarchy, this MAY be the [superuser ability `*`](#41-superuser).
+For `ucan:my` and `ucan:as` capabilities limited to some scheme, the ability MUST be one normally associated with that resource. As it belongs to every ability hierarchy, this MAY be the [superuser ability `*`](#41-superuser).
 
 ``` json
-{"with": "my:dns", "can": "crud/UPDATE"}
-{"with": "my:dns", "can": "*"}
+{"with": "ucan:my:dns", "can": "crud/UPDATE"}
+{"with": "ucan:my:dns", "can": "*"}
 ```
 
-## 4.3 UCAN Redelegation
+## 4.3 UCAN Selection
 
-### 4.3.1 `ucan` Scheme
+### 4.3.1 `ucan:token` Scheme
 
-The `ucan` URI scheme defines addressing for UCANs.
+The `ucan:token` URI scheme defines addressing for UCANs.
 
 ``` abnf
-ucan = "ucan:" selector
+ucan = "ucan:token" selector
 selector = "*" / cid
 ```
 
-`ucan:*` represents all of the UCANs in the current proofs array. If selecting a particular proof (i.e. not the wildcard), then the [CID](#56-content-identifiers) MUST be used. In the case of selecting a particular proof, the validator MUST check that the delegated content address is listed in the proofs (`prf`) field.
+`ucan:token:*` represents all of the UCANs in the current proofs array. If selecting a particular proof (i.e. not the wildcard), then the [CID](#56-content-identifiers) MUST be used. In the case of selecting a particular proof, the validator MUST check that the delegated content address is listed in the proofs (`prf`) field.
 
-### 4.3.2 `ucan` Abilities
+### 4.3.2 `ucan:token` Abilities
 
-The `ucan` scheme MUST accept the following ability: `ucan/DELEGATE`. This ability redelegates all of the capabilities in the selected proof(s).
+The `ucan:token` scheme MUST accept the following ability: `ucan/DELEGATE`. This ability redelegates all of the capabilities in the selected proof(s).
 
 `ucan/delegate` is distinct from the superuser ability and acts as a re-export of the selected abilities. If an attenuated resource or capability is desired, it MUST be explicitly listed without the `ucan` URI scheme.
 
 ``` js
 [
   { 
-    "with": "ucan:bafkreihogico5an3e2xy3fykalfwxxry7itbhfcgq6f47sif6d7w6uk2ze",
+    "with": "ucan:token:bafkreihogico5an3e2xy3fykalfwxxry7itbhfcgq6f47sif6d7w6uk2ze",
     "can": "ucan/DELEGATE"
   }, 
   { 
-    "with": "ucan:*", 
+    "with": "ucan:token:*", 
     "can": "ucan/DELEGATE" 
   }
 ]

--- a/README.md
+++ b/README.md
@@ -443,12 +443,12 @@ The superuser ability MUST be denoted `*`. This is the maximum ability and may b
 
 This is useful in several cases, for example:
 
-1. When delegating all resources, like in a [`my` scheme](#42-owned-resources)
+1. When delegating all resources, like in a [`ucan:my` scheme](#42-owned-resources)
 2. To grant the maximum ability when the current ability semantics may be extended later
 
 ## 4.2 Owned Resources
 
-The `my` URI scheme represents ownership over a resource — typically by parenthood — at decision-time (i.e. the validator's "now"). Resources that are created after the UCAN was created MUST be included. This higher-order scheme describes delegating some or all ambient authority to another DID.
+The `ucan:my` URI scheme represents ownership over a resource — typically by parenthood — at decision-time (i.e. the validator's "now"). Resources that are created after the UCAN was created MUST be included. This higher-order scheme describes delegating some or all ambient authority to another DID.
 
 The use case of "pairing" two DIDs by delegating all current and future resources is not uncommon when a user would like to use multiple devices as "root" but does not have access to all of them directly at all times. An everyday use case for this is a user signing into multiple devices, using them both with full rights.
 
@@ -459,11 +459,11 @@ ownershipscheme = "ucan:my:" target
 target = "*" / <scheme> / <uri>
 ```
 
-### 4.2.1 `my` Delegation By Parenthood
+### 4.2.1 `ucan:my` Delegation By Parenthood
 
 Capabilities being delegated by parenthood (the "apex" delegation) MUST be prefixed with `my:`. Including this prefix disambiguates that the source of this capability is the current issuer's owned resources.
 
-Without this prefix, the ambiguity in provenance can be exploited by a malicious user in an unrelated proof, forcing the validly delegated capability to appear as though it has an invalid ownership claim. The `my:` prefix resolved this issue by making introduction of a capability by parenthood explicit.
+Without this prefix, the ambiguity in provenance can be exploited by a malicious user in an unrelated proof, forcing the validly delegated capability to appear as though it has an invalid ownership claim. The `ucan:my:` prefix resolved this issue by making introduction of a capability by parenthood explicit.
 
 #### 4.2.1.1 Example
 


### PR DESCRIPTION
✨ **NB: this is a PR against #55, not `main`** ✨

A suggestion from Irakli and Hugo a few weeks back was to namespace all of the "first party" resources like `ucan:`, `my:`, and `as:`. Of course this creates a conflict with the existing `ucan:` URI.

This uses more characters, but has a few advantages:

* Leaves the top-level namespace more clean (someone else can claim `my:` later)
* Clear that these are all UCAN-specific ("special") resources

I broke this into its own PR because while I'm 99% sure this is a good idea, I want to play with the idea and exact labels a bit (such as `ucan:token:...`).

An open question is if the `can: *` super user ability should also be prefixed for consistency as `can: ucan/*`. I don't think that this actually adds clarity, but can see arguments both ways. FWIW, we captured a [this short HackMD](https://hackmd.io/jO5xcBDPQp6WZINuX8FJYA) as part of the live call, and it doesn't have the `ucan/` prefix.

@matheus23 any thoughts?

# Change Log

| Before | After |
|--------|-------|
| `my:dns` | `ucan:my:dns` |
| `as:did:key:zAlice` | `ucan:as:did:key:zAlice` |
| `ucan:bafyabcdef` | `ucan:token:bafyabcdef` |