### PR TITLE
fix: superuser ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Abilities MUST NOT be case sensitive. For example, `http/post`, `http/POST`, `HT
 
 There MUST be at least one path segment as a namespace. For example, `http/put` and `db/put` MUST be treated as unique from each other.
 
-The only reserved ability MUST be the un-namespaced [`"*"` (superuser)](#41-superuser), which MUST be allowed on any resource.
+The only reserved ability MUST be [`"*/*"` (top/superuser)](#52-top), which MUST be allowed on any resource.
 
 ## 2.4 Capability
 


### PR DESCRIPTION
As far as I can tell, `*` was removed in [this PR](https://github.com/ucan-wg/spec/pull/55/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L367) but _was_ top/super before it became `*/*`.

This PR updates the reference to be `*/*` and fixes the link to the relevant section in the spec.

Signed-off-by: Alan Shaw <alan.shaw@protocol.ai>