### PR TITLE
feat: reverts super user notation to *

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,12 +529,12 @@ If an attenuated resource or capability is desired, it MUST be explicitly listed
 
 ## 5.2 Top
 
-The "top" (or "super user") ability MUST be denoted `*/*`. The top ability grants access to all other capabilities for the specified resource, across all possible namespaces. Top corresponds to an "all" matcher, whereas [delegation](#51-ucan-delegation) corresponds to "any" in the UCAN chain. The top ability is useful when "linking" agents by delegating all access to resource(s). This is the most powerful ability, and as such it SHOULD be handled with care.
+The "top" (or "super user") ability MUST be denoted `*`. The top ability grants access to all other capabilities for the specified resource, across all possible namespaces. Top corresponds to an "all" matcher, whereas [delegation](#51-ucan-delegation) corresponds to "any" in the UCAN chain. The top ability is useful when "linking" agents by delegating all access to resource(s). This is the most powerful ability, and as such it SHOULD be handled with care.
 
 ```
                                            ┌───────┐
                                            │       │
-                                           │  */*  │
+                                           │   *   │
                                            │       │
                                            └▲──▲──▲┘
                                             │  │  │


### PR DESCRIPTION
Reverts super user notation from `*/*` back to `*`, with following justification

1. dag.house updated to 0.9 but with assumption that super user notation was `*`
   - Spec end up using `*/*` in few places but `*` in other, so we missed it.
   - Even if we add support for `*/*` we'd have to continue supporting `*`.
   - No one seems to have updated to `*/*` so maybe we can just revert to `*`.
2. notation `*/*` seems misleading because it leads to to believe `*/list` is also possible, in contract `*` doesn't invoke that misunderstanding 