### PR TITLE
Fix broken anchor in multicodec `0x55` link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1077,7 +1077,7 @@ Were a PITM attack successfully performed on a UCAN delegation, the proof chain 
 [disjunction]: https://en.wikipedia.org/wiki/Logical_disjunction
 [invocation]: https://github.com/ucan-wg/invocation
 [prf field]: #3271-prf-field
-[raw data multicodec]: https://github.com/multiformats/multicodec/blob/master/table.csv#L39
+[raw data multicodec]: https://github.com/multiformats/multicodec/blob/master/table.csv#L41
 [replay attack prevention]: #93-replay-attack-prevention
 [revocation]: #66-revocation
 [rights amplification]: #64-rights-amplification

--- a/README.md
+++ b/README.md
@@ -1077,7 +1077,7 @@ Were a PITM attack successfully performed on a UCAN delegation, the proof chain 
 [disjunction]: https://en.wikipedia.org/wiki/Logical_disjunction
 [invocation]: https://github.com/ucan-wg/invocation
 [prf field]: #3271-prf-field
-[raw data multicodec]: https://github.com/multiformats/multicodec/blob/master/table.csv#L41
+[raw data multicodec]: https://github.com/multiformats/multicodec/blob/a03169371c0a4aec0083febc996c38c3846a0914/table.csv?plain=1#L41
 [replay attack prevention]: #93-replay-attack-prevention
 [revocation]: #66-revocation
 [rights amplification]: #64-rights-amplification


### PR DESCRIPTION
Closes #164 

Using a permalink per @bumblefudge's suggestion. I don't think it's a huge problem if the table updates, especially since removing entries from Multocodec is so rare.