### PR TITLE
Link to FIDO web page not zip file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1031,7 +1031,7 @@ Were a PITM attack successfully performed on a UCAN delegation, the proof chain 
 [Dan Finlay]: https://github.com/danfinlay
 [Daniel Holmgren]: https://github.com/dholms
 [ECDSA security]: https://en.wikipedia.org/wiki/Elliptic_Curve_Digital_Signature_Algorithm#Security
-[FIDO]: https://fidoalliance.org/fido-authentication/
+[FIDO]: https://fidoalliance.org/what-is-fido/
 [Fission]: https://fission.codes
 [Hugo Dias]: https://github.com/hugomrdias
 [Irakli Gozalishvili]: https://github.com/Gozala


### PR DESCRIPTION
The link to FIDO triggers a zip file download, maybe better to link to a web page?
This one does show up a sign-up modal as soon as you visit, maybe there are better pages to link to.