### PR TITLE
Update Varsig prefix to Varsig v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,10 +571,11 @@ For example:
 
 ``` js
 [
-  {"/": {"bytes": "7aEDQLYvb3lygk9yvAbk0OZD0q+iF9c3+wpZC4YlFThkiNShcVriobPFr/wl3akjM18VvIv/Zw2LtA4uUmB5m8PWEAU"}},
+  { "/": {"bytes": "bdNVZn+uTrQ8bgq5LocO2y3gqIyuEtvYWRUH9YT+SRK6v/SX8bjt+VZ9JIPVTdxkWb6nhVKBt6JGpgnjABpOCA"}},
   {
-    "h": {"/": {"bytes": "NBIFEgEAcQ"}},
+    "h": {"/": {"bytes": "NAAB7QEO0AET"}}, // i.e. signed with Ed25519
     "ucan/example@1.0.0-rc.1": {
+      // Body fields, for example:
       "hello": "world"
     }
   }

--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ For example:
 [
   { "/": {"bytes": "bdNVZn+uTrQ8bgq5LocO2y3gqIyuEtvYWRUH9YT+SRK6v/SX8bjt+VZ9JIPVTdxkWb6nhVKBt6JGpgnjABpOCA"}},
   {
-    "h": {"/": {"bytes": "NAAB7QEO0AET"}}, // i.e. signed with Ed25519
+    "h": {"/": {"bytes": "NAAB7QEO0AETcQ"}}, // i.e. signed with Ed25519, encoded with DAG-CBOR
     "ucan/example@1.0.0-rc.1": {
       // Body fields, for example:
       "hello": "world"


### PR DESCRIPTION
Varsig v1.0 includes a varsig version segment. Also switched to Ed25519 because really no one should use RSA especially now that WebCrypto supports Ed25519

|        | Base64           | Varsig          | Algo              | Encoding |
|--------|------------------|-----------------|-------------------|---|
| Before | `NBIFEgEAcQ`     | V0: `0x34`   | RSA 2048 + SHA256 | DAG-CBOR |
| After  | `NAAB7QEO0AETcQ` | V1: `0x34 0x01` | Ed25519 | DAG-CBOR |