### PR TITLE
chore: add note about empty segments

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,7 @@ While arbitrary semantics MAY be described, they MUST apply to the target resour
 
 ### Segment Structure
 
-Commands MUST be lowercase, and begin with a slash (`/`). Segments MUST be separated by a slash. A trailing slash MUST NOT be present. All of the following are syntactically valid Commands:
+Commands MUST be lowercase, and begin with a slash (`/`). Segments MUST be separated by a slash. A trailing slash MUST NOT be present. Segment MUST NOT be empty. All of the following are syntactically valid Commands:
 
 * `/`
 * `/crud`


### PR DESCRIPTION
I ran into issues caused by decode/encode being lossy, which was cause by cmd serialization as mentioned here https://github.com/ucan-wg/delegation/issues/26. Spec is ambiguous in regards to empty segments so I'm proposing to amend it to be explicit about it