### PR TITLE
fix: invocation proof order

### DIFF
--- a/fixtures/1.0.0/invocation.json
+++ b/fixtures/1.0.0/invocation.json
@@ -1,5 +1,5 @@
 {
-  "comments": "Encoded as dag-json.",
+  "comments": "Encoded as dag-json. Time field is the time at which the validation should occur - a Unix timestamp in seconds.",
   "invalid": [
     {
       "description": "it has no proofs",
@@ -12,7 +12,8 @@
         }
       },
       "name": "no proof",
-      "proofs": []
+      "proofs": [],
+      "time": 1767225600
     },
     {
       "description": "a proof is not provided or resolvable externally",
@@ -25,7 +26,8 @@
         }
       },
       "name": "missing proof",
-      "proofs": []
+      "proofs": [],
+      "time": 1767225600
     },
     {
       "description": "a proof is expired",
@@ -34,7 +36,7 @@
       },
       "invocation": {
         "/": {
-          "bytes": "glhAupTs833VJzKG3oeSpebiP/5P8AfBdRxEbUc9DxVRpbKXsysDTSnqftMLktOkWnlVmCGLiLzqh9uWKMQR4ERpCaJhaEg0Ae0B7QETcXN1Y2FuL2ludkAxLjAuMC1yYy4xqGNjbWRpL21zZy9zZW5kY2V4cPZjaWF0Gmj1e4BjaXNzeDhkaWQ6a2V5Ono2TWtnR3lrTjlBUk5GakV6b3dWcTRtTFAya0w0TnN5QWFER1hlSkZRNXFFMWJmZ2NwcmaB2CpYJQABcRIgahqZy6Hcb2Q/Q6g1uJviOY/c7oHsoNyBTh+eDpoV3dJjc3VieDhkaWQ6a2V5Ono2TWttSmNlVm9RU0hzNDVjUmVFWG9MdFdtMXdvc0NHOFJMeGZLd2h4b3F6b1RrQ2RhcmdzoGVub25jZVAFBgcIBQYHCAUGBwgFBgcI"
+          "bytes": "glhAAOaIOueAN2CArEtmK1PE5B0h8Xha4ThT/n/Pvk+zdJDdUSJ6sUFHFpSl6uOefYdeYYAfEOLGMqYxL4jHJ7xpAKJhaEg0Ae0B7QETcXN1Y2FuL2ludkAxLjAuMC1yYy4xqWNhdWR4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDY2NtZGkvbXNnL3NlbmRjZXhw9mNpYXQaaPV7gGNpc3N4OGRpZDprZXk6ejZNa2dHeWtOOUFSTkZqRXpvd1ZxNG1MUDJrTDROc3lBYURHWGVKRlE1cUUxYmZnY3ByZoHYKlglAAFxEiBqGpnLodxvZD9DqDW4m+I5j9zugeyg3IFOH54OmhXd0mNzdWJ4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6ZGFyZ3OgZW5vbmNlUAUGBwgFBgcIBQYHCAUGBwg"
         }
       },
       "name": "expired proof",
@@ -44,7 +46,8 @@
             "bytes": "glhAet8bzLxBK7Oeqxt6t/eeTYyHb/wh7odbGXA8weuljc9COjyNhs/DaMd8YyQH2TF3UyB36oEKm/TDY3DGyvkXDqJhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa2dHeWtOOUFSTkZqRXpvd1ZxNG1MUDJrTDROc3lBYURHWGVKRlE1cUUxYmZnY2NtZGkvbXNnL3NlbmRjZXhwGmj2GDNjaXNzeDhkaWQ6a2V5Ono2TWttVDlqNmZWWnF6WFY4dTJ3VlZTdTQ5Z1lTUllHU1FuZHVXWEY2Zm9BSnJxemNwb2yAY3N1Yng4ZGlkOmtleTp6Nk1rbVQ5ajZmVlpxelhWOHUyd1ZWU3U0OWdZU1JZR1NRbmR1V1hGNmZvQUpycXplbm9uY2VQAQIDBAECAwQBAgMEAQIDBA"
           }
         }
-      ]
+      ],
+      "time": 1767225600
     },
     {
       "description": "a proof has a not before time in the future",
@@ -53,7 +56,7 @@
       },
       "invocation": {
         "/": {
-          "bytes": "glhAbt3YbyszHCOW27S8A6Xy8fR/S2iDH2L8lYgyBoOkzgoC4Syeg2zcP/Hi7DXDobFrLlYWqgdpemdYKRe4jEOUBaJhaEg0Ae0B7QETcXN1Y2FuL2ludkAxLjAuMC1yYy4xqGNjbWRpL21zZy9zZW5kY2V4cPZjaWF0Gmj1e4BjaXNzeDhkaWQ6a2V5Ono2TWtnR3lrTjlBUk5GakV6b3dWcTRtTFAya0w0TnN5QWFER1hlSkZRNXFFMWJmZ2NwcmaB2CpYJQABcRIghcgCW54v0moLFh3AXOyu5eUzEy73I5sonBNPd+6avkBjc3VieDhkaWQ6a2V5Ono2TWttSmNlVm9RU0hzNDVjUmVFWG9MdFdtMXdvc0NHOFJMeGZLd2h4b3F6b1RrQ2RhcmdzoGVub25jZVAFBgcIBQYHCAUGBwgFBgcI"
+          "bytes": "glhAXFhk3c75sRgt4PLjKhM/g1C5gNb4X4RuueyEcCAxwjsduTLafzUpODnllMQQoPlAifrbRnREaHSrsnlckCZDC6JhaEg0Ae0B7QETcXN1Y2FuL2ludkAxLjAuMC1yYy4xqWNhdWR4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDY2NtZGkvbXNnL3NlbmRjZXhw9mNpYXQaaPV7gGNpc3N4OGRpZDprZXk6ejZNa2dHeWtOOUFSTkZqRXpvd1ZxNG1MUDJrTDROc3lBYURHWGVKRlE1cUUxYmZnY3ByZoHYKlglAAFxEiCFyAJbni/SagsWHcBc7K7l5TMTLvcjmyicE0937pq+QGNzdWJ4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6ZGFyZ3OgZW5vbmNlUAUGBwgFBgcIBQYHCAUGBwg"
         }
       },
       "name": "inactive proof",
@@ -63,7 +66,8 @@
             "bytes": "glhAcWHiqJIcx2+8bfTXblonOaoi4if0kXWSZnw8ijBAZlblRspyJvt+YGSIMGSEEp/BIPmr2Qem3F/NqvASpitnBaJhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xqGNhdWR4OGRpZDprZXk6ejZNa2dHeWtOOUFSTkZqRXpvd1ZxNG1MUDJrTDROc3lBYURHWGVKRlE1cUUxYmZnY2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y25iZhsAAAA6//RBf2Nwb2yAY3N1Yng4ZGlkOmtleTp6Nk1rbVQ5ajZmVlpxelhWOHUyd1ZWU3U0OWdZU1JZR1NRbmR1V1hGNmZvQUpycXplbm9uY2VQAQIDBAECAwQBAgMEAQIDBA"
           }
         }
-      ]
+      ],
+      "time": 1767225600
     },
     {
       "description": "the issuer of a delegation in the proof chain is not the audience of the next delegation",
@@ -72,22 +76,23 @@
       },
       "invocation": {
         "/": {
-          "bytes": "glhAV3jsUznrpXG+hac6mx+04u5vGp0vhJBRCQ4qbYD7AlfswNdxHWNBNKnU8VE84xdGR5N7Xc6fmxJfX8SbLd//AaJhaEg0Ae0B7QETcXN1Y2FuL2ludkAxLjAuMC1yYy4xqGNjbWRpL21zZy9zZW5kY2V4cPZjaWF0Gmj1e4BjaXNzeDhkaWQ6a2V5Ono2TWtnR3lrTjlBUk5GakV6b3dWcTRtTFAya0w0TnN5QWFER1hlSkZRNXFFMWJmZ2NwcmaC2CpYJQABcRIguIISrxoWsh3AnaF/wx3Skabg7tI8LNRsZi8txfnlPu7YKlglAAFxEiDBaGyFMdE9Md5+YWVv9anDlPXtGqNAmeBIYZifKHpV2WNzdWJ4OGRpZDprZXk6ejZNa2g3d0p0UmVDZWVUOXlEUjJuUjUyb21LQ2F5UzZ6Ymc4dG5XOEpvazlDSmhrZGFyZ3OgZW5vbmNlUAEBAwgBAQMIAQEDCAEBAwg"
+          "bytes": "glhAk22FKu8Xjatd2VgHG+vIT9373AfkusV23A8gQwY/aFv47GyQ1XlwBCAtKaNmF4hxOPVfICBO8+90dmj2oSGaD6JhaEg0Ae0B7QETcXN1Y2FuL2ludkAxLjAuMC1yYy4xqGNjbWRpL21zZy9zZW5kY2V4cPZjaWF0Gmj1e4BjaXNzeDhkaWQ6a2V5Ono2TWtnR3lrTjlBUk5GakV6b3dWcTRtTFAya0w0TnN5QWFER1hlSkZRNXFFMWJmZ2NwcmaC2CpYJQABcRIgwWhshTHRPTHefmFlb/Wpw5T17RqjQJngSGGYnyh6VdnYKlglAAFxEiC4ghKvGhayHcCdoX/DHdKRpuDu0jws1GxmLy3F+eU+7mNzdWJ4OGRpZDprZXk6ejZNa2g3d0p0UmVDZWVUOXlEUjJuUjUyb21LQ2F5UzZ6Ymc4dG5XOEpvazlDSmhrZGFyZ3OgZW5vbmNlUAEBAwgBAQMIAQEDCAEBAwg"
         }
       },
       "name": "proof principal alignment",
       "proofs": [
         {
           "/": {
-            "bytes": "glhAg4P89/nYQzrLHgCddyhPslAuiA/mgfDkIZBRKI2vQs8ybbtLHYSW+uo4Zgfn4blseU4YABu1tJs8ClXSpJ5cDaJhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa2dHeWtOOUFSTkZqRXpvd1ZxNG1MUDJrTDROc3lBYURHWGVKRlE1cUUxYmZnY2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y3BvbIBjc3VieDhkaWQ6a2V5Ono2TWtoN3dKdFJlQ2VlVDl5RFIyblI1Mm9tS0NheVM2emJnOHRuVzhKb2s5Q0poa2Vub25jZVAFBgcIBQYHCAUGBwgFBgcI"
+            "bytes": "glhA47UkXV3nVndtGRqPLlB2F3/TNDd5lg5F8++X6oqe+SENmVD8Jvj3+MwPSEW50vNlpQ3HXv8/RwXax5TFjU/7BaJhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDY2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa2g3d0p0UmVDZWVUOXlEUjJuUjUyb21LQ2F5UzZ6Ymc4dG5XOEpvazlDSmhrY3BvbIBjc3VieDhkaWQ6a2V5Ono2TWtoN3dKdFJlQ2VlVDl5RFIyblI1Mm9tS0NheVM2emJnOHRuVzhKb2s5Q0poa2Vub25jZVABAgMEAQIDBAECAwQBAgME"
           }
         },
         {
           "/": {
-            "bytes": "glhA47UkXV3nVndtGRqPLlB2F3/TNDd5lg5F8++X6oqe+SENmVD8Jvj3+MwPSEW50vNlpQ3HXv8/RwXax5TFjU/7BaJhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDY2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa2g3d0p0UmVDZWVUOXlEUjJuUjUyb21LQ2F5UzZ6Ymc4dG5XOEpvazlDSmhrY3BvbIBjc3VieDhkaWQ6a2V5Ono2TWtoN3dKdFJlQ2VlVDl5RFIyblI1Mm9tS0NheVM2emJnOHRuVzhKb2s5Q0poa2Vub25jZVABAgMEAQIDBAECAwQBAgME"
+            "bytes": "glhAg4P89/nYQzrLHgCddyhPslAuiA/mgfDkIZBRKI2vQs8ybbtLHYSW+uo4Zgfn4blseU4YABu1tJs8ClXSpJ5cDaJhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa2dHeWtOOUFSTkZqRXpvd1ZxNG1MUDJrTDROc3lBYURHWGVKRlE1cUUxYmZnY2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y3BvbIBjc3VieDhkaWQ6a2V5Ono2TWtoN3dKdFJlQ2VlVDl5RFIyblI1Mm9tS0NheVM2emJnOHRuVzhKb2s5Q0poa2Vub25jZVAFBgcIBQYHCAUGBwgFBgcI"
           }
         }
-      ]
+      ],
+      "time": 1767225600
     },
     {
       "description": "the audience of the delegation is not the issuer of the invocation",
@@ -96,22 +101,23 @@
       },
       "invocation": {
         "/": {
-          "bytes": "glhA11XpH25/k+6xFkH3aiIZxEeFI2NE/9Iy4Di2VraiHbffqKeMlcSVN+DpE84xcdVbG/iv5e3kxFnoNVQHbaSyB6JhaEg0Ae0B7QETcXN1Y2FuL2ludkAxLjAuMC1yYy4xqGNjbWRpL21zZy9zZW5kY2V4cPZjaWF0Gmj1e4BjaXNzeDhkaWQ6a2V5Ono2TWtnR3lrTjlBUk5GakV6b3dWcTRtTFAya0w0TnN5QWFER1hlSkZRNXFFMWJmZ2NwcmaC2CpYJQABcRIgMbdCFygvZdJDnLIXS+18gygbucsf10G6i6Qnv5hx7ALYKlglAAFxEiDBaGyFMdE9Md5+YWVv9anDlPXtGqNAmeBIYZifKHpV2WNzdWJ4OGRpZDprZXk6ejZNa2g3d0p0UmVDZWVUOXlEUjJuUjUyb21LQ2F5UzZ6Ymc4dG5XOEpvazlDSmhrZGFyZ3OgZW5vbmNlUAEBAwgBAQMIAQEDCAEBAwg"
+          "bytes": "glhAbCTct6BWsI3gfcFEdzxHZJmXLYXYARhMdFFHmf8rsz8EfYjmrcOWuT1uaK04AqU2yI+4eRGAqSOr5BVIUHyADaJhaEg0Ae0B7QETcXN1Y2FuL2ludkAxLjAuMC1yYy4xqGNjbWRpL21zZy9zZW5kY2V4cPZjaWF0Gmj1e4BjaXNzeDhkaWQ6a2V5Ono2TWtnR3lrTjlBUk5GakV6b3dWcTRtTFAya0w0TnN5QWFER1hlSkZRNXFFMWJmZ2NwcmaC2CpYJQABcRIgwWhshTHRPTHefmFlb/Wpw5T17RqjQJngSGGYnyh6VdnYKlglAAFxEiAxt0IXKC9l0kOcshdL7XyDKBu5yx/XQbqLpCe/mHHsAmNzdWJ4OGRpZDprZXk6ejZNa2g3d0p0UmVDZWVUOXlEUjJuUjUyb21LQ2F5UzZ6Ymc4dG5XOEpvazlDSmhrZGFyZ3OgZW5vbmNlUAEBAwgBAQMIAQEDCAEBAwg"
         }
       },
       "name": "invocation principal alignment",
       "proofs": [
         {
           "/": {
-            "bytes": "glhAvrf2Fq+KzyVLbMrHV+darhgqtO583QC8U7ZcPV6SgkN6r5fC/SbyzBcoaGxKgrRsE5wHZPXBBlaGAf4H6e40DqJhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDY3BvbIBjc3VieDhkaWQ6a2V5Ono2TWtoN3dKdFJlQ2VlVDl5RFIyblI1Mm9tS0NheVM2emJnOHRuVzhKb2s5Q0poa2Vub25jZVAFBgcIBQYHCAUGBwgFBgcI"
+            "bytes": "glhA47UkXV3nVndtGRqPLlB2F3/TNDd5lg5F8++X6oqe+SENmVD8Jvj3+MwPSEW50vNlpQ3HXv8/RwXax5TFjU/7BaJhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDY2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa2g3d0p0UmVDZWVUOXlEUjJuUjUyb21LQ2F5UzZ6Ymc4dG5XOEpvazlDSmhrY3BvbIBjc3VieDhkaWQ6a2V5Ono2TWtoN3dKdFJlQ2VlVDl5RFIyblI1Mm9tS0NheVM2emJnOHRuVzhKb2s5Q0poa2Vub25jZVABAgMEAQIDBAECAwQBAgME"
           }
         },
         {
           "/": {
-            "bytes": "glhA47UkXV3nVndtGRqPLlB2F3/TNDd5lg5F8++X6oqe+SENmVD8Jvj3+MwPSEW50vNlpQ3HXv8/RwXax5TFjU/7BaJhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDY2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa2g3d0p0UmVDZWVUOXlEUjJuUjUyb21LQ2F5UzZ6Ymc4dG5XOEpvazlDSmhrY3BvbIBjc3VieDhkaWQ6a2V5Ono2TWtoN3dKdFJlQ2VlVDl5RFIyblI1Mm9tS0NheVM2emJnOHRuVzhKb2s5Q0poa2Vub25jZVABAgMEAQIDBAECAwQBAgME"
+            "bytes": "glhAvrf2Fq+KzyVLbMrHV+darhgqtO583QC8U7ZcPV6SgkN6r5fC/SbyzBcoaGxKgrRsE5wHZPXBBlaGAf4H6e40DqJhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDY3BvbIBjc3VieDhkaWQ6a2V5Ono2TWtoN3dKdFJlQ2VlVDl5RFIyblI1Mm9tS0NheVM2emJnOHRuVzhKb2s5Q0poa2Vub25jZVAFBgcIBQYHCAUGBwgFBgcI"
           }
         }
-      ]
+      ],
+      "time": 1767225600
     },
     {
       "description": "the subject is not the same for every delegation in the proof chain",
@@ -120,22 +126,23 @@
       },
       "invocation": {
         "/": {
-          "bytes": "glhA0Tyn7Eh9SFJnYJ4Q3/n0QYFdEnVHgHze9o1woHh9qXpBJIFy2e09r3dvziYIDi4aR98JpvoHb1oWSl/JxXyYDqJhaEg0Ae0B7QETcXN1Y2FuL2ludkAxLjAuMC1yYy4xqGNjbWRpL21zZy9zZW5kY2V4cPZjaWF0Gmj1e4BjaXNzeDhkaWQ6a2V5Ono2TWtnR3lrTjlBUk5GakV6b3dWcTRtTFAya0w0TnN5QWFER1hlSkZRNXFFMWJmZ2NwcmaC2CpYJQABcRIgMzCHsHkGw9b93/fHkm1OAu7W39a8kV2no54Oc03pnALYKlglAAFxEiCAZApnv/CyrmAr4/yrhGrA5kKuHKIghMOkcz9tkg+nJGNzdWJ4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDZGFyZ3OgZW5vbmNlUAEBAwgBAQMIAQEDCAEBAwg"
+          "bytes": "glhAlO72HaD6YHqVgu74XmgZnd0HUbM0Ho3EE8gDTwOPsje4IcQVFW5k2NCpJvJzt+UVZoCvMl8SVpBbghComHjMBqJhaEg0Ae0B7QETcXN1Y2FuL2ludkAxLjAuMC1yYy4xqGNjbWRpL21zZy9zZW5kY2V4cPZjaWF0Gmj1e4BjaXNzeDhkaWQ6a2V5Ono2TWtnR3lrTjlBUk5GakV6b3dWcTRtTFAya0w0TnN5QWFER1hlSkZRNXFFMWJmZ2NwcmaC2CpYJQABcRIggGQKZ7/wsq5gK+P8q4RqwOZCrhyiIITDpHM/bZIPpyTYKlglAAFxEiAzMIeweQbD1v3f98eSbU4C7tbf1ryRXaejng5zTemcAmNzdWJ4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDZGFyZ3OgZW5vbmNlUAEBAwgBAQMIAQEDCAEBAwg"
         }
       },
       "name": "proof subject alignment",
       "proofs": [
         {
           "/": {
-            "bytes": "glhA18glIcesPTSsyxIvvSsnrLctcBHs20EEAUI+WSnOJBwBElj2b6z0UhR2pz5MSR8cRxPWdp5NffgA08Hn7EsrB6JhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa2dHeWtOOUFSTkZqRXpvd1ZxNG1MUDJrTDROc3lBYURHWGVKRlE1cUUxYmZnY2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y3BvbIBjc3VieDhkaWQ6a2V5Ono2TWttVDlqNmZWWnF6WFY4dTJ3VlZTdTQ5Z1lTUllHU1FuZHVXWEY2Zm9BSnJxemVub25jZVAFBgcIBQYHCAUGBwgFBgcI"
+            "bytes": "glhA1IoOl5rpsUsdwbfKD6Ly/Tf6h90ODLY5ru2FSDJ9s2Z5/kLmFvBlypu9Ff0fnoa7+pKtVlDsucD5aCYINbhRC6JhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDY3BvbIBjc3VieDhkaWQ6a2V5Ono2TWttSmNlVm9RU0hzNDVjUmVFWG9MdFdtMXdvc0NHOFJMeGZLd2h4b3F6b1RrQ2Vub25jZVABAgMEAQIDBAECAwQBAgME"
           }
         },
         {
           "/": {
-            "bytes": "glhA1IoOl5rpsUsdwbfKD6Ly/Tf6h90ODLY5ru2FSDJ9s2Z5/kLmFvBlypu9Ff0fnoa7+pKtVlDsucD5aCYINbhRC6JhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDY3BvbIBjc3VieDhkaWQ6a2V5Ono2TWttSmNlVm9RU0hzNDVjUmVFWG9MdFdtMXdvc0NHOFJMeGZLd2h4b3F6b1RrQ2Vub25jZVABAgMEAQIDBAECAwQBAgME"
+            "bytes": "glhA18glIcesPTSsyxIvvSsnrLctcBHs20EEAUI+WSnOJBwBElj2b6z0UhR2pz5MSR8cRxPWdp5NffgA08Hn7EsrB6JhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa2dHeWtOOUFSTkZqRXpvd1ZxNG1MUDJrTDROc3lBYURHWGVKRlE1cUUxYmZnY2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y3BvbIBjc3VieDhkaWQ6a2V5Ono2TWttVDlqNmZWWnF6WFY4dTJ3VlZTdTQ5Z1lTUllHU1FuZHVXWEY2Zm9BSnJxemVub25jZVAFBgcIBQYHCAUGBwgFBgcI"
           }
         }
-      ]
+      ],
+      "time": 1767225600
     },
     {
       "description": "the subject of the invocation is not the same as the subject of the delegation",
@@ -144,22 +151,23 @@
       },
       "invocation": {
         "/": {
-          "bytes": "glhA07DNIr7D+7fvC9HQjAFj0aWAUV5HAGohKLU15hOXgFcqETC2AfmWwuP9+F3c5ElM1Rb+6nbm4C3POSU3c7PuAKJhaEg0Ae0B7QETcXN1Y2FuL2ludkAxLjAuMC1yYy4xqGNjbWRpL21zZy9zZW5kY2V4cPZjaWF0Gmj1e4BjaXNzeDhkaWQ6a2V5Ono2TWtnR3lrTjlBUk5GakV6b3dWcTRtTFAya0w0TnN5QWFER1hlSkZRNXFFMWJmZ2NwcmaC2CpYJQABcRIgeYBtHcIlGGAgkV3vk0qB0sDih8Kco3ny/NHWBzcsM4HYKlglAAFxEiCAZApnv/CyrmAr4/yrhGrA5kKuHKIghMOkcz9tkg+nJGNzdWJ4OGRpZDprZXk6ejZNa2g3d0p0UmVDZWVUOXlEUjJuUjUyb21LQ2F5UzZ6Ymc4dG5XOEpvazlDSmhrZGFyZ3OgZW5vbmNlUAEBAwgBAQMIAQEDCAEBAwg"
+          "bytes": "glhACTPh/BfVEST0S902BlfNjGS/+gEdUbQYDn/iaQxtBrZt9LMzHWWlVaPonKVeZfccvza204WnaO9ieym4lATvC6JhaEg0Ae0B7QETcXN1Y2FuL2ludkAxLjAuMC1yYy4xqGNjbWRpL21zZy9zZW5kY2V4cPZjaWF0Gmj1e4BjaXNzeDhkaWQ6a2V5Ono2TWtnR3lrTjlBUk5GakV6b3dWcTRtTFAya0w0TnN5QWFER1hlSkZRNXFFMWJmZ2NwcmaC2CpYJQABcRIggGQKZ7/wsq5gK+P8q4RqwOZCrhyiIITDpHM/bZIPpyTYKlglAAFxEiB5gG0dwiUYYCCRXe+TSoHSwOKHwpyjefL80dYHNywzgWNzdWJ4OGRpZDprZXk6ejZNa2g3d0p0UmVDZWVUOXlEUjJuUjUyb21LQ2F5UzZ6Ymc4dG5XOEpvazlDSmhrZGFyZ3OgZW5vbmNlUAEBAwgBAQMIAQEDCAEBAwg"
         }
       },
       "name": "invocation subject alignment",
       "proofs": [
         {
           "/": {
-            "bytes": "glhAlC+rtXKanMs7eUsDKDbzBoPI1RIoBhxs3nHh/XbBc9Ou5quAnDM987yV+PAgR6X8nmJ8hQozLL3yEJyCKhuyA6JhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa2dHeWtOOUFSTkZqRXpvd1ZxNG1MUDJrTDROc3lBYURHWGVKRlE1cUUxYmZnY2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y3BvbIBjc3VieDhkaWQ6a2V5Ono2TWttSmNlVm9RU0hzNDVjUmVFWG9MdFdtMXdvc0NHOFJMeGZLd2h4b3F6b1RrQ2Vub25jZVAFBgcIBQYHCAUGBwgFBgcI"
+            "bytes": "glhA1IoOl5rpsUsdwbfKD6Ly/Tf6h90ODLY5ru2FSDJ9s2Z5/kLmFvBlypu9Ff0fnoa7+pKtVlDsucD5aCYINbhRC6JhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDY3BvbIBjc3VieDhkaWQ6a2V5Ono2TWttSmNlVm9RU0hzNDVjUmVFWG9MdFdtMXdvc0NHOFJMeGZLd2h4b3F6b1RrQ2Vub25jZVABAgMEAQIDBAECAwQBAgME"
           }
         },
         {
           "/": {
-            "bytes": "glhA1IoOl5rpsUsdwbfKD6Ly/Tf6h90ODLY5ru2FSDJ9s2Z5/kLmFvBlypu9Ff0fnoa7+pKtVlDsucD5aCYINbhRC6JhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDY3BvbIBjc3VieDhkaWQ6a2V5Ono2TWttSmNlVm9RU0hzNDVjUmVFWG9MdFdtMXdvc0NHOFJMeGZLd2h4b3F6b1RrQ2Vub25jZVABAgMEAQIDBAECAwQBAgME"
+            "bytes": "glhAlC+rtXKanMs7eUsDKDbzBoPI1RIoBhxs3nHh/XbBc9Ou5quAnDM987yV+PAgR6X8nmJ8hQozLL3yEJyCKhuyA6JhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa2dHeWtOOUFSTkZqRXpvd1ZxNG1MUDJrTDROc3lBYURHWGVKRlE1cUUxYmZnY2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y3BvbIBjc3VieDhkaWQ6a2V5Ono2TWttSmNlVm9RU0hzNDVjUmVFWG9MdFdtMXdvc0NHOFJMeGZLd2h4b3F6b1RrQ2Vub25jZVAFBgcIBQYHCAUGBwgFBgcI"
           }
         }
-      ]
+      ],
+      "time": 1767225600
     },
     {
       "description": "the invocation is expired",
@@ -168,7 +176,7 @@
       },
       "invocation": {
         "/": {
-          "bytes": "glhAdRZEsVZjlWYsJywI48Ejjc1qPkr68ChTUU6Fgeq1JNY+uTB93mRA+uk5RShNJOVvdjR2fWtqpIiKp1ar4NohBaJhaEg0Ae0B7QETcXN1Y2FuL2ludkAxLjAuMC1yYy4xqGNjbWRpL21zZy9zZW5kY2V4cBpo9hgzY2lhdBpo9XuAY2lzc3g4ZGlkOmtleTp6Nk1rZ0d5a045QVJORmpFem93VnE0bUxQMmtMNE5zeUFhREdYZUpGUTVxRTFiZmdjcHJmgdgqWCUAAXESIDCPAmRWfAh+wcp6VINAQwn7pLa5hSYy0rviivw1yA5qY3N1Yng4ZGlkOmtleTp6Nk1rbUpjZVZvUVNIczQ1Y1JlRVhvTHRXbTF3b3NDRzhSTHhmS3doeG9xem9Ua0NkYXJnc6Blbm9uY2VQBQYHCAUGBwgFBgcIBQYHCA"
+          "bytes": "glhATdWBwjtwcHmJpD14UBNbTkDFW+W/ZNZcdqeKqKLkIoIqA1PmnwRDTrvNaIYfmH7JZkMOoVHCq5H67T8fksZVCaJhaEg0Ae0B7QETcXN1Y2FuL2ludkAxLjAuMC1yYy4xqWNhdWR4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDY2NtZGkvbXNnL3NlbmRjZXhwGmj2GDNjaWF0Gmj1e4BjaXNzeDhkaWQ6a2V5Ono2TWtnR3lrTjlBUk5GakV6b3dWcTRtTFAya0w0TnN5QWFER1hlSkZRNXFFMWJmZ2NwcmaB2CpYJQABcRIgMI8CZFZ8CH7BynpUg0BDCfuktrmFJjLSu+KK/DXIDmpjc3VieDhkaWQ6a2V5Ono2TWttVDlqNmZWWnF6WFY4dTJ3VlZTdTQ5Z1lTUllHU1FuZHVXWEY2Zm9BSnJxemRhcmdzoGVub25jZVAFBgcIBQYHCAUGBwgFBgcI"
         }
       },
       "name": "expired invocation",
@@ -178,7 +186,8 @@
             "bytes": "glhAR4mfb8ah/x4Ec2ncbW1jfm4T/SSqX2rbe7XSLiXZPTRaSsdR94U/dyC0dviEpYjou21f0iC4DUho1DFzms/bAKJhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa2dHeWtOOUFSTkZqRXpvd1ZxNG1MUDJrTDROc3lBYURHWGVKRlE1cUUxYmZnY2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y3BvbIBjc3VieDhkaWQ6a2V5Ono2TWttVDlqNmZWWnF6WFY4dTJ3VlZTdTQ5Z1lTUllHU1FuZHVXWEY2Zm9BSnJxemVub25jZVABAgMEAQIDBAECAwQBAgME"
           }
         }
-      ]
+      ],
+      "time": 1767225600
     },
     {
       "description": "the signature of a proof is not verifiable",
@@ -187,7 +196,7 @@
       },
       "invocation": {
         "/": {
-          "bytes": "glhAHU3J47ECvjF9KCPCsIMmur6KzCbZbN1aIhzr7omh4Fpsi+XvLrnTX699HZwgGK4tBf3pi+cFrpxxR10KHxRLAqJhaEg0Ae0B7QETcXN1Y2FuL2ludkAxLjAuMC1yYy4xqGNjbWRpL21zZy9zZW5kY2V4cPZjaWF0Gmj1e4BjaXNzeDhkaWQ6a2V5Ono2TWtnR3lrTjlBUk5GakV6b3dWcTRtTFAya0w0TnN5QWFER1hlSkZRNXFFMWJmZ2NwcmaB2CpYJQABcRIgZ2PkUy2e7sFj+vPz64bBtCo2vEklHkkDcH2bcqqGZu1jc3VieDhkaWQ6a2V5Ono2TWttSmNlVm9RU0hzNDVjUmVFWG9MdFdtMXdvc0NHOFJMeGZLd2h4b3F6b1RrQ2RhcmdzoGVub25jZVAFBgcIBQYHCAUGBwgFBgcI"
+          "bytes": "glhAbVsSO5sjEISDcUh46jS8X5QVActQyj2yNuGnbxVYl3i85MpO4g0clEMsYvLGIOvVqfJ+g7w5ETyiL4lMeGetC6JhaEg0Ae0B7QETcXN1Y2FuL2ludkAxLjAuMC1yYy4xqWNhdWR4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDY2NtZGkvbXNnL3NlbmRjZXhw9mNpYXQaaPV7gGNpc3N4OGRpZDprZXk6ejZNa2dHeWtOOUFSTkZqRXpvd1ZxNG1MUDJrTDROc3lBYURHWGVKRlE1cUUxYmZnY3ByZoHYKlglAAFxEiBnY+RTLZ7uwWP68/PrhsG0Kja8SSUeSQNwfZtyqoZm7WNzdWJ4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6ZGFyZ3OgZW5vbmNlUAUGBwgFBgcIBQYHCAUGBwg"
         }
       },
       "name": "invalid proof signature",
@@ -197,7 +206,8 @@
             "bytes": "gkMBAgOiYWhINAHtAe0BE3FzdWNhbi9kbGdAMS4wLjAtcmMuMadjYXVkeDhkaWQ6a2V5Ono2TWtnR3lrTjlBUk5GakV6b3dWcTRtTFAya0w0TnN5QWFER1hlSkZRNXFFMWJmZ2NjbWRpL21zZy9zZW5kY2V4cPZjaXNzeDhkaWQ6a2V5Ono2TWttVDlqNmZWWnF6WFY4dTJ3VlZTdTQ5Z1lTUllHU1FuZHVXWEY2Zm9BSnJxemNwb2yAY3N1Yng4ZGlkOmtleTp6Nk1rbVQ5ajZmVlpxelhWOHUyd1ZWU3U0OWdZU1JZR1NRbmR1V1hGNmZvQUpycXplbm9uY2VQAQIDBAECAwQBAgMEAQIDBA"
           }
         }
-      ]
+      ],
+      "time": 1767225600
     },
     {
       "description": "the signature of the invocation is not verifiable",
@@ -210,7 +220,8 @@
         }
       },
       "name": "invalid invocation signature",
-      "proofs": []
+      "proofs": [],
+      "time": 1767225600
     },
     {
       "description": "the root delegation has a null subject",
@@ -229,7 +240,8 @@
             "bytes": "glhA33+8rqRZRkeqDa0Yw2ihnWeEDIJMRw0NhO9GwJo4Y106Yw6FpzxZZAAHrhHwrSc5KIsz1hjnD9j+6N1IQiz0B6JhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa2dHeWtOOUFSTkZqRXpvd1ZxNG1MUDJrTDROc3lBYURHWGVKRlE1cUUxYmZnY2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y3BvbIBjc3Vi9mVub25jZVABAgMEAQIDBAECAwQBAgME"
           }
         }
-      ]
+      ],
+      "time": 1767225600
     },
     {
       "description": "the invocation violates a policy set in an delegation",
@@ -248,7 +260,8 @@
             "bytes": "glhAJjUfUFt3TlI4pdVLEsOiqy60JIBJ7UPie3bvIdCtPa8pizVxOALlXPXgiPbY04X91l/pqfjLmjfvO0gukE/zBaJhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa2dHeWtOOUFSTkZqRXpvd1ZxNG1MUDJrTDROc3lBYURHWGVKRlE1cUUxYmZnY2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y3BvbIGDYj09Zy5hbnN3ZXIYKmNzdWJ4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6ZW5vbmNlUAECAwQBAgMEAQIDBAECAwQ"
           }
         }
-      ]
+      ],
+      "time": 1767225600
     }
   ],
   "valid": [
@@ -260,7 +273,8 @@
         }
       },
       "name": "self signed",
-      "proofs": []
+      "proofs": [],
+      "time": 1767225600
     },
     {
       "description": "a single proof that has no expiry",
@@ -276,7 +290,8 @@
             "bytes": "glhAR4mfb8ah/x4Ec2ncbW1jfm4T/SSqX2rbe7XSLiXZPTRaSsdR94U/dyC0dviEpYjou21f0iC4DUho1DFzms/bAKJhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa2dHeWtOOUFSTkZqRXpvd1ZxNG1MUDJrTDROc3lBYURHWGVKRlE1cUUxYmZnY2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y3BvbIBjc3VieDhkaWQ6a2V5Ono2TWttVDlqNmZWWnF6WFY4dTJ3VlZTdTQ5Z1lTUllHU1FuZHVXWEY2Zm9BSnJxemVub25jZVABAgMEAQIDBAECAwQBAgME"
           }
         }
-      ]
+      ],
+      "time": 1767225600
     },
     {
       "description": "a single proof that has no expiry and is active (a not before timestamp in the past)",
@@ -292,70 +307,74 @@
             "bytes": "glhATG1Om9LOQykef7Xp3WfygLsX1/4Fuul3y9BtWwHwwtXRAlKQg/TF45kmpiCEWPvO3fpeKFle3mrWV7dCEZNIAaJhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xqGNhdWR4OGRpZDprZXk6ejZNa2dHeWtOOUFSTkZqRXpvd1ZxNG1MUDJrTDROc3lBYURHWGVKRlE1cUUxYmZnY2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y25iZhpo9hgzY3BvbIBjc3VieDhkaWQ6a2V5Ono2TWttVDlqNmZWWnF6WFY4dTJ3VlZTdTQ5Z1lTUllHU1FuZHVXWEY2Zm9BSnJxemVub25jZVABAgMEAQIDBAECAwQBAgME"
           }
         }
-      ]
+      ],
+      "time": 1767225600
     },
     {
       "description": "a proof chain more than one delegation long",
       "invocation": {
         "/": {
-          "bytes": "glhA74q4zj+6ilxI0pO3LjdqWwwXha7edZX71ZxAb8AzD2/M/s4NykMa3YVKbpV5CiyB8onoFYNHTKAeIDqV4xVaAaJhaEg0Ae0B7QETcXN1Y2FuL2ludkAxLjAuMC1yYy4xqGNjbWRpL21zZy9zZW5kY2V4cPZjaWF0Gmj1e4BjaXNzeDhkaWQ6a2V5Ono2TWtnR3lrTjlBUk5GakV6b3dWcTRtTFAya0w0TnN5QWFER1hlSkZRNXFFMWJmZ2NwcmaC2CpYJQABcRIgeYBtHcIlGGAgkV3vk0qB0sDih8Kco3ny/NHWBzcsM4HYKlglAAFxEiCAZApnv/CyrmAr4/yrhGrA5kKuHKIghMOkcz9tkg+nJGNzdWJ4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDZGFyZ3OgZW5vbmNlUAEBAwgBAQMIAQEDCAEBAwg"
+          "bytes": "glhAuowwaBvbdDnJ6Ae2iFnbFyrwCSbnodimsqQmuH1dnD7x7hVm5RhTpAr3QNViLZcbJjzDddzKPZKmhOQL9kKjAKJhaEg0Ae0B7QETcXN1Y2FuL2ludkAxLjAuMC1yYy4xqGNjbWRpL21zZy9zZW5kY2V4cPZjaWF0Gmj1e4BjaXNzeDhkaWQ6a2V5Ono2TWtnR3lrTjlBUk5GakV6b3dWcTRtTFAya0w0TnN5QWFER1hlSkZRNXFFMWJmZ2NwcmaC2CpYJQABcRIggGQKZ7/wsq5gK+P8q4RqwOZCrhyiIITDpHM/bZIPpyTYKlglAAFxEiB5gG0dwiUYYCCRXe+TSoHSwOKHwpyjefL80dYHNywzgWNzdWJ4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDZGFyZ3OgZW5vbmNlUAEBAwgBAQMIAQEDCAEBAwg"
         }
       },
       "name": "multiple proofs",
       "proofs": [
         {
           "/": {
-            "bytes": "glhAlC+rtXKanMs7eUsDKDbzBoPI1RIoBhxs3nHh/XbBc9Ou5quAnDM987yV+PAgR6X8nmJ8hQozLL3yEJyCKhuyA6JhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa2dHeWtOOUFSTkZqRXpvd1ZxNG1MUDJrTDROc3lBYURHWGVKRlE1cUUxYmZnY2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y3BvbIBjc3VieDhkaWQ6a2V5Ono2TWttSmNlVm9RU0hzNDVjUmVFWG9MdFdtMXdvc0NHOFJMeGZLd2h4b3F6b1RrQ2Vub25jZVAFBgcIBQYHCAUGBwgFBgcI"
+            "bytes": "glhA1IoOl5rpsUsdwbfKD6Ly/Tf6h90ODLY5ru2FSDJ9s2Z5/kLmFvBlypu9Ff0fnoa7+pKtVlDsucD5aCYINbhRC6JhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDY3BvbIBjc3VieDhkaWQ6a2V5Ono2TWttSmNlVm9RU0hzNDVjUmVFWG9MdFdtMXdvc0NHOFJMeGZLd2h4b3F6b1RrQ2Vub25jZVABAgMEAQIDBAECAwQBAgME"
           }
         },
         {
           "/": {
-            "bytes": "glhA1IoOl5rpsUsdwbfKD6Ly/Tf6h90ODLY5ru2FSDJ9s2Z5/kLmFvBlypu9Ff0fnoa7+pKtVlDsucD5aCYINbhRC6JhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDY3BvbIBjc3VieDhkaWQ6a2V5Ono2TWttSmNlVm9RU0hzNDVjUmVFWG9MdFdtMXdvc0NHOFJMeGZLd2h4b3F6b1RrQ2Vub25jZVABAgMEAQIDBAECAwQBAgME"
+            "bytes": "glhAlC+rtXKanMs7eUsDKDbzBoPI1RIoBhxs3nHh/XbBc9Ou5quAnDM987yV+PAgR6X8nmJ8hQozLL3yEJyCKhuyA6JhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa2dHeWtOOUFSTkZqRXpvd1ZxNG1MUDJrTDROc3lBYURHWGVKRlE1cUUxYmZnY2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y3BvbIBjc3VieDhkaWQ6a2V5Ono2TWttSmNlVm9RU0hzNDVjUmVFWG9MdFdtMXdvc0NHOFJMeGZLd2h4b3F6b1RrQ2Vub25jZVAFBgcIBQYHCAUGBwgFBgcI"
           }
         }
-      ]
+      ],
+      "time": 1767225600
     },
     {
       "description": "a proof chain more than one delegation long where one or more proofs have a not before time in the past",
       "invocation": {
         "/": {
-          "bytes": "glhAf9uM0B1/N4AncATj1QGvs1s2OwR9p2Ha6s8zpbgFEVvQ2sUYZhsUQQ58TIOgzipukcVsipU7NbxJwWFGy/iEC6JhaEg0Ae0B7QETcXN1Y2FuL2ludkAxLjAuMC1yYy4xqGNjbWRpL21zZy9zZW5kY2V4cPZjaWF0Gmj1e4BjaXNzeDhkaWQ6a2V5Ono2TWtnR3lrTjlBUk5GakV6b3dWcTRtTFAya0w0TnN5QWFER1hlSkZRNXFFMWJmZ2NwcmaC2CpYJQABcRIgWsLKG1xNCqD8GkqaZ/HxOEtMcnBqSebL3O7sCjUa8lXYKlglAAFxEiCAZApnv/CyrmAr4/yrhGrA5kKuHKIghMOkcz9tkg+nJGNzdWJ4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDZGFyZ3OgZW5vbmNlUAEBAwgBAQMIAQEDCAEBAwg"
+          "bytes": "glhAKjwCYxC46BAlemzISFY7HeEuwpKbpaGBfBXRMJ/5+DhSsJacos3Jx8gncdFD/QoN5PdYMzLpYAIr0qZyL3M5CKJhaEg0Ae0B7QETcXN1Y2FuL2ludkAxLjAuMC1yYy4xqGNjbWRpL21zZy9zZW5kY2V4cPZjaWF0Gmj1e4BjaXNzeDhkaWQ6a2V5Ono2TWtnR3lrTjlBUk5GakV6b3dWcTRtTFAya0w0TnN5QWFER1hlSkZRNXFFMWJmZ2NwcmaC2CpYJQABcRIggGQKZ7/wsq5gK+P8q4RqwOZCrhyiIITDpHM/bZIPpyTYKlglAAFxEiBawsobXE0KoPwaSppn8fE4S0xycGpJ5svc7uwKNRryVWNzdWJ4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDZGFyZ3OgZW5vbmNlUAEBAwgBAQMIAQEDCAEBAwg"
         }
       },
       "name": "multiple active proofs",
       "proofs": [
         {
           "/": {
-            "bytes": "glhAGEQPkrF++2YMScD/UnB2gaGhwENHr4uUvGW5vIWmL5845cVBU5uxBknS5dVD+FU5rtuhH7JsExMsw9Gbvn6uBqJhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xqGNhdWR4OGRpZDprZXk6ejZNa2dHeWtOOUFSTkZqRXpvd1ZxNG1MUDJrTDROc3lBYURHWGVKRlE1cUUxYmZnY2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y25iZhpo9hgzY3BvbIBjc3VieDhkaWQ6a2V5Ono2TWttSmNlVm9RU0hzNDVjUmVFWG9MdFdtMXdvc0NHOFJMeGZLd2h4b3F6b1RrQ2Vub25jZVAFBgcIBQYHCAUGBwgFBgcI"
+            "bytes": "glhA1IoOl5rpsUsdwbfKD6Ly/Tf6h90ODLY5ru2FSDJ9s2Z5/kLmFvBlypu9Ff0fnoa7+pKtVlDsucD5aCYINbhRC6JhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDY3BvbIBjc3VieDhkaWQ6a2V5Ono2TWttSmNlVm9RU0hzNDVjUmVFWG9MdFdtMXdvc0NHOFJMeGZLd2h4b3F6b1RrQ2Vub25jZVABAgMEAQIDBAECAwQBAgME"
           }
         },
         {
           "/": {
-            "bytes": "glhA1IoOl5rpsUsdwbfKD6Ly/Tf6h90ODLY5ru2FSDJ9s2Z5/kLmFvBlypu9Ff0fnoa7+pKtVlDsucD5aCYINbhRC6JhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDY3BvbIBjc3VieDhkaWQ6a2V5Ono2TWttSmNlVm9RU0hzNDVjUmVFWG9MdFdtMXdvc0NHOFJMeGZLd2h4b3F6b1RrQ2Vub25jZVABAgMEAQIDBAECAwQBAgME"
+            "bytes": "glhAGEQPkrF++2YMScD/UnB2gaGhwENHr4uUvGW5vIWmL5845cVBU5uxBknS5dVD+FU5rtuhH7JsExMsw9Gbvn6uBqJhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xqGNhdWR4OGRpZDprZXk6ejZNa2dHeWtOOUFSTkZqRXpvd1ZxNG1MUDJrTDROc3lBYURHWGVKRlE1cUUxYmZnY2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y25iZhpo9hgzY3BvbIBjc3VieDhkaWQ6a2V5Ono2TWttSmNlVm9RU0hzNDVjUmVFWG9MdFdtMXdvc0NHOFJMeGZLd2h4b3F6b1RrQ2Vub25jZVAFBgcIBQYHCAUGBwgFBgcI"
           }
         }
-      ]
+      ],
+      "time": 1767225600
     },
     {
       "description": "a proof chain with a powerline delegation (null value for subject)",
       "invocation": {
         "/": {
-          "bytes": "glhAziUOhJX5mwR8NeB0oeN3N114ud9NPX4VSsZl5pvMwv1/J0y4YMO4dMnZMP4luZWVdMJDh384Ttf/p7U0tslaDKJhaEg0Ae0B7QETcXN1Y2FuL2ludkAxLjAuMC1yYy4xqGNjbWRpL21zZy9zZW5kY2V4cPZjaWF0Gmj1e4BjaXNzeDhkaWQ6a2V5Ono2TWtnR3lrTjlBUk5GakV6b3dWcTRtTFAya0w0TnN5QWFER1hlSkZRNXFFMWJmZ2NwcmaC2CpYJQABcRIgYLbz3tTH2Ehxb9e7SjBbdU2a29964JR6TvWS9W0xlxbYKlglAAFxEiCAZApnv/CyrmAr4/yrhGrA5kKuHKIghMOkcz9tkg+nJGNzdWJ4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDZGFyZ3OgZW5vbmNlUAEBAwgBAQMIAQEDCAEBAwg"
+          "bytes": "glhAO/jcArn1o84J6AwtvnhR3ufYh8KcfgYgCGzy9Y06F7QIGSZHJ9Gp4DbflNnVPc17q7xwTcyB2UCP5AoZcbadDKJhaEg0Ae0B7QETcXN1Y2FuL2ludkAxLjAuMC1yYy4xqGNjbWRpL21zZy9zZW5kY2V4cPZjaWF0Gmj1e4BjaXNzeDhkaWQ6a2V5Ono2TWtnR3lrTjlBUk5GakV6b3dWcTRtTFAya0w0TnN5QWFER1hlSkZRNXFFMWJmZ2NwcmaC2CpYJQABcRIggGQKZ7/wsq5gK+P8q4RqwOZCrhyiIITDpHM/bZIPpyTYKlglAAFxEiBgtvPe1MfYSHFv17tKMFt1TZrb33rglHpO9ZL1bTGXFmNzdWJ4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDZGFyZ3OgZW5vbmNlUAEBAwgBAQMIAQEDCAEBAwg"
         }
       },
       "name": "powerline",
       "proofs": [
         {
           "/": {
-            "bytes": "glhAGIeARv6xTuoTDPhUnUfrJ+nNTp1DIhvYzmt55gB2vqAzlei5W5QfvGcSOlnZtCGmQjf/LT2pHFGTDJOqvrScB6JhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa2dHeWtOOUFSTkZqRXpvd1ZxNG1MUDJrTDROc3lBYURHWGVKRlE1cUUxYmZnY2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y3BvbIBjc3Vi9mVub25jZVAFBgcIBQYHCAUGBwgFBgcI"
+            "bytes": "glhA1IoOl5rpsUsdwbfKD6Ly/Tf6h90ODLY5ru2FSDJ9s2Z5/kLmFvBlypu9Ff0fnoa7+pKtVlDsucD5aCYINbhRC6JhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDY3BvbIBjc3VieDhkaWQ6a2V5Ono2TWttSmNlVm9RU0hzNDVjUmVFWG9MdFdtMXdvc0NHOFJMeGZLd2h4b3F6b1RrQ2Vub25jZVABAgMEAQIDBAECAwQBAgME"
           }
         },
         {
           "/": {
-            "bytes": "glhA1IoOl5rpsUsdwbfKD6Ly/Tf6h90ODLY5ru2FSDJ9s2Z5/kLmFvBlypu9Ff0fnoa7+pKtVlDsucD5aCYINbhRC6JhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21KY2VWb1FTSHM0NWNSZUVYb0x0V20xd29zQ0c4Ukx4Zkt3aHhvcXpvVGtDY3BvbIBjc3VieDhkaWQ6a2V5Ono2TWttSmNlVm9RU0hzNDVjUmVFWG9MdFdtMXdvc0NHOFJMeGZLd2h4b3F6b1RrQ2Vub25jZVABAgMEAQIDBAECAwQBAgME"
+            "bytes": "glhAGIeARv6xTuoTDPhUnUfrJ+nNTp1DIhvYzmt55gB2vqAzlei5W5QfvGcSOlnZtCGmQjf/LT2pHFGTDJOqvrScB6JhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa2dHeWtOOUFSTkZqRXpvd1ZxNG1MUDJrTDROc3lBYURHWGVKRlE1cUUxYmZnY2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y3BvbIBjc3Vi9mVub25jZVAFBgcIBQYHCAUGBwgFBgcI"
           }
         }
-      ]
+      ],
+      "time": 1767225600
     },
     {
       "description": "a policy that matches the invocation arguments",
@@ -371,7 +390,8 @@
             "bytes": "glhAJjUfUFt3TlI4pdVLEsOiqy60JIBJ7UPie3bvIdCtPa8pizVxOALlXPXgiPbY04X91l/pqfjLmjfvO0gukE/zBaJhaEg0Ae0B7QETcXN1Y2FuL2RsZ0AxLjAuMC1yYy4xp2NhdWR4OGRpZDprZXk6ejZNa2dHeWtOOUFSTkZqRXpvd1ZxNG1MUDJrTDROc3lBYURHWGVKRlE1cUUxYmZnY2NtZGkvbXNnL3NlbmRjZXhw9mNpc3N4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6Y3BvbIGDYj09Zy5hbnN3ZXIYKmNzdWJ4OGRpZDprZXk6ejZNa21UOWo2ZlZacXpYVjh1MndWVlN1NDlnWVNSWUdTUW5kdVdYRjZmb0FKcnF6ZW5vbmNlUAECAwQBAgMEAQIDBAECAwQ"
           }
         }
-      ]
+      ],
+      "time": 1767225600
     }
   ],
   "version": "1.0.0-rc.1"


### PR DESCRIPTION
resolves https://github.com/ucan-wg/spec/issues/201

This PR fixes the proof order in valid invocation fixtures. It also adds a `time` field - a Unix timestamp in seconds at which the validation should occur.

refs https://github.com/alanshaw/ucantone/pull/2